### PR TITLE
Avoid eagerly consuming the instantiationStack stack of plugins.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,18 @@ function getNodeInfo(node) {
   //
   // We don't to use prototypal inheritance (Object.create) because some test
   // code can get confused if hasOwnProperty isn't true.
-  var nodeInfo = {}
+  var nodeInfo = {
+    // lazily return the original instantiation stack
+    // this avoids eagerly accessing the stacks, which is costly
+    get instantiationStack() {
+      return originalNodeInfo.instantiationStack;
+    }
+  };
   for (var key in originalNodeInfo) {
+    if (key === 'instantiationStack') {
+      continue;
+    }
+
     nodeInfo[key] = originalNodeInfo[key]
   }
 


### PR DESCRIPTION
Previously, we would force eager calculation of error stack traces even if we would never need them (due to the copying method we use). This tweaks things slightly, to avoid eager computation of the `.instantiationStack` property.


References:

* https://github.com/broccolijs/broccoli-plugin/pull/55
* https://github.com/broccolijs/broccoli-source/pull/23
